### PR TITLE
Shading jar to simplify loading dependencies in hive

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,12 @@ Sketch Adaptors for Hive [![Build Status](https://travis-ci.org/DataSketches/ske
 =================
 Depends on sketches-core.
 
+To use Hive UDFs, you should do the following:
+
+1. Register the JAR file with Hive: 
+  - `hive> add jar sketches-hive-0.1.0-incDeps.jar`
+2. Register UDF functions with Hive:
+  - `hive> create temporary function estimate as 'com.yahoo.sketches.hive.theta.EstimateSketchUDF';`
+  - `hive> create temporary function dataToSketch as 'com.yahoo.sketches.hive.theta.DataToSketchUDAF';`
+3. Run a query: 
+  - `hive> select estimate(dataToSketch(myCol, 16384, 1.0)) from myTable where color = blue;`

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,28 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.4.2</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <artifactSet>
+                <includes>
+                  <include>com.yahoo.datasketches:sketches-core</include>
+                </includes>
+              </artifactSet>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>incDeps</shadedClassifierName>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Including the contents of sketches-core into the sketches-hive jar file
to avoid version conflicts in hive and to simplify the jars that need to
be loaded in order to use the hive UDF functions.

Also, updating readme to give basic instructions for how to use the Hive
UDFs.