### PR TITLE
Code cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>com.yahoo.datasketches</groupId>
       <artifactId>sketches-core</artifactId>
-      <version>0.2.0</version>
+      <version>0.2.2</version>
     </dependency>
 
     <!-- Hive Dependencies (provided scope) -->

--- a/src/main/java/com/yahoo/sketches/hive/theta/ExcludeSketchUDF.java
+++ b/src/main/java/com/yahoo/sketches/hive/theta/ExcludeSketchUDF.java
@@ -8,7 +8,6 @@ import org.apache.hadoop.hive.ql.exec.UDF;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.IntWritable;
 
-import com.yahoo.sketches.Family;
 import com.yahoo.sketches.memory.NativeMemory;
 import com.yahoo.sketches.theta.AnotB;
 import com.yahoo.sketches.theta.SetOperation;
@@ -59,7 +58,7 @@ public class ExcludeSketchUDF extends UDF {
       sketch_size = sketchSize.get();
     }
 
-    AnotB anotb = (AnotB) SetOperation.builder().build(sketch_size, Family.A_NOT_B);
+    AnotB anotb = SetOperation.builder().buildANotB(sketch_size);
 
     anotb.update(firstHeapSketch, secondHeapSketch);
 

--- a/src/main/java/com/yahoo/sketches/hive/theta/IntersectSketchUDF.java
+++ b/src/main/java/com/yahoo/sketches/hive/theta/IntersectSketchUDF.java
@@ -8,7 +8,6 @@ import org.apache.hadoop.hive.ql.exec.UDF;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.IntWritable;
 
-import com.yahoo.sketches.Family;
 import com.yahoo.sketches.memory.NativeMemory;
 import com.yahoo.sketches.theta.Intersection;
 import com.yahoo.sketches.theta.SetOperation;
@@ -58,7 +57,7 @@ public class IntersectSketchUDF extends UDF {
       sketch_size = sketchSize.get();
     }
 
-    Intersection intersect = (Intersection) SetOperation.builder().build(sketch_size, Family.INTERSECTION);
+    Intersection intersect = SetOperation.builder().buildIntersection(sketch_size);
     
     intersect.update(firstHeapSketch);
     intersect.update(secondHeapSketch);

--- a/src/main/java/com/yahoo/sketches/hive/theta/MergeSketchUDAF.java
+++ b/src/main/java/com/yahoo/sketches/hive/theta/MergeSketchUDAF.java
@@ -28,7 +28,6 @@ import java.util.List;
 import com.yahoo.sketches.memory.NativeMemory;
 import com.yahoo.sketches.theta.CompactSketch;
 import com.yahoo.sketches.theta.SetOperation;
-import com.yahoo.sketches.theta.Sketch;
 import com.yahoo.sketches.theta.Union;
 
 /**
@@ -203,9 +202,7 @@ public class MergeSketchUDAF extends AbstractGenericUDAFResolver {
 
       NativeMemory memorySketch = new NativeMemory(serializedSketch);
 
-      Sketch incomingSketch = Sketch.wrap(memorySketch);
-
-      buf.getUnion().update(incomingSketch);
+      buf.getUnion().update(memorySketch);
     }
 
     /**

--- a/src/main/java/com/yahoo/sketches/hive/theta/SampleSketchUDF.java
+++ b/src/main/java/com/yahoo/sketches/hive/theta/SampleSketchUDF.java
@@ -33,7 +33,7 @@ public class SampleSketchUDF extends UDF {
    *          Should be greater than zero and less than or equal to 1.0 
    * @return The sampled sketch encoded as a BytesWritable
    */
-  public BytesWritable evaluate(BytesWritable binarySketch, int sketchSize, double probability) {
+  public BytesWritable evaluate(BytesWritable binarySketch, int sketchSize, float probability) {
     
     // Null checks
     if (binarySketch == null) {
@@ -46,13 +46,8 @@ public class SampleSketchUDF extends UDF {
       return null;
     }
     
-    //Size and probability checks that choose defaults rather than error out
-    int sketch_size = (sketchSize > 0)? sketchSize : DEFAULT_SIZE; //allows <=0.
-    
-    float p = (float) (((probability < 0.0) || (probability > 1.0))? 1.0 : probability); 
-    
     //  The builder will catch errors with improper sketchSize or probability
-    Union union = SetOperation.builder().setP(p).buildUnion(sketch_size);
+    Union union = SetOperation.builder().setP(probability).buildUnion(sketchSize);
 
     union.update(new NativeMemory(serializedSketch)); //Union can accept Memory object directly
 

--- a/src/main/java/com/yahoo/sketches/hive/theta/UnionSketchUDF.java
+++ b/src/main/java/com/yahoo/sketches/hive/theta/UnionSketchUDF.java
@@ -8,7 +8,6 @@ import org.apache.hadoop.hive.ql.exec.UDF;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.IntWritable;
 
-import com.yahoo.sketches.Family;
 import com.yahoo.sketches.memory.NativeMemory;
 import com.yahoo.sketches.theta.SetOperation;
 import com.yahoo.sketches.theta.Sketch;
@@ -41,7 +40,7 @@ public class UnionSketchUDF extends UDF {
       sketch_size = sketchSize.get();
     }
 
-    Union union = (Union) SetOperation.builder().build(sketch_size, Family.UNION);
+    Union union = SetOperation.builder().buildUnion(sketch_size);
 
     // update union first sketch, if null do nothing
     if (firstSketch != null && firstSketch.getLength() > 0) {

--- a/src/main/java/com/yahoo/sketches/hive/theta/UnionSketchUDF.java
+++ b/src/main/java/com/yahoo/sketches/hive/theta/UnionSketchUDF.java
@@ -39,13 +39,13 @@ public class UnionSketchUDF extends UDF {
     
     Union union = SetOperation.builder().buildUnion(sketch_size);
 
-    // update union with first sketch, if null or empty do nothing
-    if (firstSketch != null && firstSketch.getLength() > 8) {
+    // update union with first sketch, if null do nothing
+    if (firstSketch != null) {
       union.update(new NativeMemory(firstSketch.getBytes()));
     }
 
-    // update union second sketch, if null or empty do nothing
-    if (secondSketch != null && secondSketch.getLength() > 8) {
+    // update union second sketch, if null do nothing
+    if (secondSketch != null) {
       union.update(new NativeMemory(secondSketch.getBytes()));
     }
 

--- a/src/main/java/com/yahoo/sketches/hive/theta/UnionSketchUDF.java
+++ b/src/main/java/com/yahoo/sketches/hive/theta/UnionSketchUDF.java
@@ -30,34 +30,26 @@ public class UnionSketchUDF extends UDF {
    *          second sketch to be unioned.
    * @param sketchSize
    *          final output unioned sketch size.
+   *          This must be a power of 2 and larger than 16. If zero, DEFAULT is used.
    * @return resulting sketch of union.
    */
   public BytesWritable evaluate(BytesWritable firstSketch, BytesWritable secondSketch, IntWritable sketchSize) {
-    int sketch_size = DEFAULT_SIZE;
-    Sketch firstHeapSketch, secondHeapSketch;
-
-    if (sketchSize != null) {
-      sketch_size = sketchSize.get();
-    }
-
+    
+    int sketch_size = (sketchSize != null)? sketchSize.get() : DEFAULT_SIZE;
+    
     Union union = SetOperation.builder().buildUnion(sketch_size);
 
-    // update union first sketch, if null do nothing
-    if (firstSketch != null && firstSketch.getLength() > 0) {
-      NativeMemory firstMemory = new NativeMemory(firstSketch.getBytes());
-      firstHeapSketch = Sketch.heapify(firstMemory);
-      union.update(firstHeapSketch);
+    // update union with first sketch, if null or empty do nothing
+    if (firstSketch != null && firstSketch.getLength() > 8) {
+      union.update(new NativeMemory(firstSketch.getBytes()));
     }
 
-    // update union second sketch, if null do nothing
-    if (secondSketch != null && secondSketch.getLength() > 0) {
-      NativeMemory secondMemory = new NativeMemory(secondSketch.getBytes());
-      secondHeapSketch = Sketch.heapify(secondMemory);
-      union.update(secondHeapSketch);
-
+    // update union second sketch, if null or empty do nothing
+    if (secondSketch != null && secondSketch.getLength() > 8) {
+      union.update(new NativeMemory(secondSketch.getBytes()));
     }
 
-    Sketch intermediateSketch = union.getResult(false, null);
+    Sketch intermediateSketch = union.getResult(false, null); //unordered CompactSketch
     byte[] resultSketch = intermediateSketch.toByteArray();
 
     BytesWritable result = new BytesWritable();

--- a/src/main/java/com/yahoo/sketches/hive/theta/UnionSketchUDF.java
+++ b/src/main/java/com/yahoo/sketches/hive/theta/UnionSketchUDF.java
@@ -40,12 +40,12 @@ public class UnionSketchUDF extends UDF {
     Union union = SetOperation.builder().buildUnion(sketch_size);
 
     // update union with first sketch, if null do nothing
-    if (firstSketch != null) {
+    if ((firstSketch != null) && (firstSketch.getLength() >= 8)) {
       union.update(new NativeMemory(firstSketch.getBytes()));
     }
 
     // update union second sketch, if null do nothing
-    if (secondSketch != null) {
+    if ((secondSketch != null) && (secondSketch.getLength() >= 8)) {
       union.update(new NativeMemory(secondSketch.getBytes()));
     }
 

--- a/src/test/java/com/yahoo/sketches/hive/theta/MergeSketchUDAFTest.java
+++ b/src/test/java/com/yahoo/sketches/hive/theta/MergeSketchUDAFTest.java
@@ -234,10 +234,10 @@ public class MergeSketchUDAFTest {
     buf.setSketchSize(512);
     buf.setUnion(isA(Union.class));
     expect(buf.getUnion()).andReturn(union);
-    union.update(isA(Sketch.class));
+    union.update(isA(Memory.class));
 
     expect(buf.getUnion()).andReturn(union).times(2);
-    union.update(isA(Sketch.class));
+    union.update(isA(Memory.class));
 
     replay(buf, union);
 

--- a/src/test/java/com/yahoo/sketches/hive/theta/MergeSketchUDAFTest.java
+++ b/src/test/java/com/yahoo/sketches/hive/theta/MergeSketchUDAFTest.java
@@ -38,7 +38,6 @@ import com.yahoo.sketches.hive.theta.MergeSketchUDAF.MergeSketchUDAFEvaluator.Me
 import com.yahoo.sketches.memory.Memory;
 import com.yahoo.sketches.theta.CompactSketch;
 import com.yahoo.sketches.theta.SetOperation;
-import com.yahoo.sketches.theta.Sketch;
 import com.yahoo.sketches.theta.Union;
 import com.yahoo.sketches.theta.UpdateSketch;
 


### PR DESCRIPTION
The new Union API allows merging of Memory sketches directly, without having to create an intermediate sketch on the heap.  The code already did this in DataToSketchUDAF, but not in some of the other classes.  I also added some qualifying comments to some of the javadoc params to fully communicate what the contract is.  I also streamlined some of the builder calls to eliminate unnecessary casting. Plus some other small code refactoring.  