### PR TITLE
convert strings to char[] before passing to sketch to avoid costly UTF-8

### DIFF
--- a/src/main/java/com/yahoo/sketches/hive/hll/SketchState.java
+++ b/src/main/java/com/yahoo/sketches/hive/hll/SketchState.java
@@ -46,7 +46,8 @@ class SketchState extends State {
       sketch_.update(PrimitiveObjectInspectorUtils.getLong(data, keyObjectInspector));
       return;
     case STRING:
-      sketch_.update(PrimitiveObjectInspectorUtils.getString(data, keyObjectInspector));
+      // conversion to char[] avoids costly UTF-8 encoding
+      sketch_.update(PrimitiveObjectInspectorUtils.getString(data, keyObjectInspector).toCharArray());
       return;
     default:
       throw new IllegalArgumentException(


### PR DESCRIPTION
encoding